### PR TITLE
chore: update maintainer from rewine to wineee across packages

### DIFF
--- a/pkgs/deepin-translation-utils/default.nix
+++ b/pkgs/deepin-translation-utils/default.nix
@@ -21,7 +21,7 @@ rustPlatform.buildRustPackage rec {
     description = "A commandline tool to help you work with translation files and Transifex configurations that are used in deepin's workflow";
     homepage = "https://github.com/linuxdeepin/deepin-translation-utils.git";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ rewine ];
+    maintainers = with lib.maintainers; [ wineee ];
     mainProgram = "deepin-translation-utils";
   };
 }

--- a/pkgs/electron-netease-cloud-music/default.nix
+++ b/pkgs/electron-netease-cloud-music/default.nix
@@ -63,7 +63,7 @@ stdenv.mkDerivation rec {
     description = "UNOFFICIAL client for music.163.com. Powered by Electron and Vue
 ";
     homepage = "https://ncm-releases.herokuapp.com";
-    maintainers = with lib.maintainers; [ rewine ];
+    maintainers = with lib.maintainers; [ wineee ];
     license = lib.licenses.gpl3Plus;
     platforms = lib.platforms.linux;
   };

--- a/pkgs/git-commit-helper/default.nix
+++ b/pkgs/git-commit-helper/default.nix
@@ -46,7 +46,7 @@ rustPlatform.buildRustPackage rec {
     description = "Ai git commit helper";
     homepage = "https://github.com/zccrs/git-commit-helper";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ rewine ];
+    maintainers = with lib.maintainers; [ wineee ];
     mainProgram = "git-commit-helper";
   };
 }

--- a/pkgs/kylin-virtual-keyboard/default.nix
+++ b/pkgs/kylin-virtual-keyboard/default.nix
@@ -69,7 +69,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Virtual keyboard based on fcitx5 InputMethod Framework";
     homepage = "https://gitee.com/openkylin/kylin-virtual-keyboard";
     license = lib.licenses.lgpl3Only;
-    maintainers = with lib.maintainers; [ rewine ];
+    maintainers = with lib.maintainers; [ wineee ];
     platforms = lib.platforms.linux;
     mainProgram = "kylin-virtual-keyboard";
   };

--- a/pkgs/kylin-wayland-compositor/default.nix
+++ b/pkgs/kylin-wayland-compositor/default.nix
@@ -87,6 +87,6 @@ stdenv.mkDerivation rec {
     homepage = "https://gitee.com/openkylin/kylin-wayland-compositor";
     license = lib.licenses.gpl1Plus;
     platforms = lib.platforms.linux;
-    maintainers = with lib.maintainers; [ rewine ];
+    maintainers = with lib.maintainers; [ wineee ];
   };
 }

--- a/pkgs/libaesgm/default.nix
+++ b/pkgs/libaesgm/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
     # upstream (http://gladman.plushost.co.uk/oldsite/AES/index.php) is not accessible
     license = licenses.asl20;
     platforms = platforms.linux;
-    maintainers = with maintainers; [ rewine ];
+    maintainers = with maintainers; [ wineee ];
   };
 }
 

--- a/pkgs/mogan/default.nix
+++ b/pkgs/mogan/default.nix
@@ -104,6 +104,6 @@ stdenv.mkDerivation rec {
     homepage    = "https://mogan.app";
     license     = lib.licenses.gpl3Plus;
     platforms   = lib.platforms.all;
-    maintainers = with lib.maintainers; [ rewine ];
+    maintainers = with lib.maintainers; [ wineee ];
   };
 }

--- a/pkgs/nowide/default.nix
+++ b/pkgs/nowide/default.nix
@@ -28,6 +28,6 @@ stdenv.mkDerivation rec {
     description = "Boost.Nowide - Standard library functions with UTF-8 API on Windows";
     homepage = "https://github.com/boostorg/nowide";
     license = licenses.boost;
-    maintainers = with maintainers; [ rewine ];
+    maintainers = with maintainers; [ wineee ];
   };
 }

--- a/pkgs/python-wayland
+++ b/pkgs/python-wayland
@@ -1,0 +1,40 @@
+{
+  lib,
+  python3,
+  fetchFromSourcehut,
+}:
+
+python3.pkgs.buildPythonApplication rec {
+  pname = "python-wayland";
+  version = "1.0.0";
+  pyproject = true;
+
+  src = fetchFromSourcehut {
+    owner = "~gk";
+    repo = "python-wayland";
+    rev = "v${version}";
+    hash = "sha256-C2o7Y7M5ebAmI6Qi7vN6uf4Aifhxh/l71K/YjZj6/f8=";
+  };
+
+  build-system = [
+    python3.pkgs.hatchling
+  ];
+
+  optional-dependencies = with python3.pkgs; {
+    dev = [
+      opencv-python
+      textual
+    ];
+  };
+
+  pythonImportsCheck = [
+    "wayland"
+  ];
+
+  meta = {
+    description = "Implementation of the Wayland protocol from scratch";
+    homepage = "https://git.sr.ht/~gk/python-wayland";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ wineee ];
+  };
+}

--- a/pkgs/wayland-debug/default.nix
+++ b/pkgs/wayland-debug/default.nix
@@ -35,7 +35,7 @@ stdenv.mkDerivation rec {
     description = "Command line tool to help debug Wayland clients and servers";
     homepage = "https://github.com/wmww/wayland-debug";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ rewine ];
+    maintainers = with lib.maintainers; [ wineee ];
     mainProgram = "wayland-debug";
   };
 }

--- a/pkgs/wayland-debug/wayland.nix
+++ b/pkgs/wayland-debug/wayland.nix
@@ -60,7 +60,7 @@ stdenv.mkDerivation (finalAttrs: {
     homepage = "https://wayland.freedesktop.org/";
     license = licenses.mit; # Expat version
     platforms = platforms.unix;
-    maintainers = with maintainers; [ rewine ];
+    maintainers = with maintainers; [ wineee ];
   };
 })
 

--- a/pkgs/wlanalyze/default.nix
+++ b/pkgs/wlanalyze/default.nix
@@ -30,7 +30,7 @@ stdenv.mkDerivation rec {
     description = "Qt UI to analyze WAYLAND_DEBUG output";
     homepage = "https://github.com/rgriebl/wlanalyze.git";
     license = lib.licenses.gpl3Only;
-    maintainers = with lib.maintainers; [ rewine ];
+    maintainers = with lib.maintainers; [ wineee ];
     mainProgram = "wlanalyze";
     platforms = lib.platforms.all;
   };

--- a/pkgs/xcursor-viewer/default.nix
+++ b/pkgs/xcursor-viewer/default.nix
@@ -29,7 +29,7 @@ stdenv.mkDerivation rec {
     description = "xcursor viewer";
     homepage = "https://github.com/drizt/xcursor-viewer";
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ rewine ];
+    maintainers = with maintainers; [ wineee ];
     mainProgram = "xcursor-viewer";
     platforms = platforms.all;
   };


### PR DESCRIPTION
Updated maintainer field in multiple package definitions from 'rewine' to 'wineee'. This change reflects the transfer of package maintenance responsibilities to a new maintainer. The packages affected include deepin-translation-utils, electron-netease-cloud-music, git-commit- helper, kylin-virtual-keyboard, kylin-wayland-compositor, libaesgm, mogan, nowide, wayland-debug, wlanalyze, and xcursor-viewer. Additionally, added a new package 'python-wayland' with wineee as the maintainer.

This maintenance update ensures proper attribution and contact information for package maintenance responsibilities without affecting functionality.

chore: 将多个软件包的维护者从 rewine 更新为 wineee

将多个软件包定义中的维护者字段从 'rewine' 更新为 'wineee'。这一变更反映
了软件包维护责任向新维护者的转移。受影响的软件包包括 deepin-translation-
utils、electron-netease-cloud-music、git-commit-helper、kylin-virtual- keyboard、kylin-wayland-compositor、libaesgm、mogan、nowide、wayland- debug、wlanalyze 和 xcursor-viewer。此外，新增了 'python-wayland' 软件 包，并将 wineee 设为其维护者。

此维护更新确保了软件包维护责任的正确归属和联系信息，不会影响功能。